### PR TITLE
Fix config parsing of bools

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	URL     string
+	APIKey  string
+	Name    string
+	Version string
+	Parent  string
+	Tags    string
+	SBOM    string
+	Poll    bool
+	Latest  bool
+}
+
+func (c *Config) validate() error {
+	if c.URL == "" {
+		return fmt.Errorf("missing required input: url (via --url or SBOM_UPLOADER_URL)")
+	}
+	if c.APIKey == "" {
+		return fmt.Errorf("missing required input: api-key (via --api-key or SBOM_UPLOADER_API_KEY)")
+	}
+	if c.Name == "" {
+		return fmt.Errorf("missing required input: name (via --name or SBOM_UPLOADER_NAME)")
+	}
+	if c.Parent == "" {
+		return fmt.Errorf("missing required input: parent (via --parent or SBOM_UPLOADER_PARENT)")
+	}
+	if c.Version == "" {
+		return fmt.Errorf("missing required input: version (via --version or SBOM_UPLOADER_VERSION)")
+	}
+	return nil
+}
+
+// loadConfig resolves configuration from flags and environment variables.
+// Flags take precedence over env vars; env vars take precedence over defaults.
+//
+// AutomaticEnv + BindPFlags has a known issue where bool flags with a false
+// default have their pflag default shadow the env var. We work around it with
+// explicit BindEnv calls for bool flags.
+// See https://github.com/spf13/viper/issues/671
+func loadConfig(flags *pflag.FlagSet) (*Config, error) {
+	v := viper.New()
+	v.SetEnvPrefix("SBOM_UPLOADER")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+	if err := errors.Join(
+		v.BindPFlags(flags),
+		v.BindEnv("poll", "SBOM_UPLOADER_POLL"),
+		v.BindEnv("latest", "SBOM_UPLOADER_LATEST"),
+	); err != nil {
+		return nil, err
+	}
+	return &Config{
+		URL:     v.GetString("url"),
+		APIKey:  v.GetString("api-key"),
+		Name:    v.GetString("name"),
+		Version: v.GetString("version"),
+		Parent:  v.GetString("parent"),
+		Tags:    v.GetString("tags"),
+		SBOM:    v.GetString("sbom"),
+		Poll:    v.GetBool("poll"),
+		Latest:  v.GetBool("latest"),
+	}, nil
+}
+
+func setFlags(s *pflag.FlagSet) {
+	s.String("url", "", "Dependency-Track API base URL or env SBOM_UPLOADER_URL")
+	s.String("api-key", "", "Dependency-Track API key or env SBOM_UPLOADER_API_KEY")
+	s.String("name", "", "Project name or env SBOM_UPLOADER_NAME")
+	s.String("version", "", "Project version or env SBOM_UPLOADER_VERSION")
+	s.String("parent", "", "Parent project name or env SBOM_UPLOADER_PARENT")
+	s.Bool("latest", true, "Mark as latest version (default true)")
+	s.Bool("poll", false, "Poll until import completes or env SBOM_UPLOADER_POLL")
+	s.String("tags", "", "Comma-separated project tags or env SBOM_UPLOADER_TAGS")
+	s.String("sbom", "", "Path to SBOM file (optional; otherwise read from stdin)")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// newFlagSet returns a FlagSet populated with the same flags as the real CLI.
+func newFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	setFlags(flags)
+	return flags
+}
+
+func TestLoadConfig_StringsFromEnvVars(t *testing.T) {
+	t.Setenv("SBOM_UPLOADER_URL", "https://example.com")
+	t.Setenv("SBOM_UPLOADER_API_KEY", "my-api-key")
+	t.Setenv("SBOM_UPLOADER_NAME", "my-project")
+	t.Setenv("SBOM_UPLOADER_VERSION", "1.2.3")
+	t.Setenv("SBOM_UPLOADER_PARENT", "my-parent")
+	t.Setenv("SBOM_UPLOADER_TAGS", "tag1,tag2")
+	t.Setenv("SBOM_UPLOADER_SBOM", "/path/to/sbom.json")
+
+	cfg, err := loadConfig(newFlagSet())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.URL != "https://example.com" {
+		t.Errorf("URL: got %q, want %q", cfg.URL, "https://example.com")
+	}
+	if cfg.APIKey != "my-api-key" {
+		t.Errorf("APIKey: got %q, want %q", cfg.APIKey, "my-api-key")
+	}
+	if cfg.Name != "my-project" {
+		t.Errorf("Name: got %q, want %q", cfg.Name, "my-project")
+	}
+	if cfg.Version != "1.2.3" {
+		t.Errorf("Version: got %q, want %q", cfg.Version, "1.2.3")
+	}
+	if cfg.Parent != "my-parent" {
+		t.Errorf("Parent: got %q, want %q", cfg.Parent, "my-parent")
+	}
+	if cfg.Tags != "tag1,tag2" {
+		t.Errorf("Tags: got %q, want %q", cfg.Tags, "tag1,tag2")
+	}
+	if cfg.SBOM != "/path/to/sbom.json" {
+		t.Errorf("SBOM: got %q, want %q", cfg.SBOM, "/path/to/sbom.json")
+	}
+}
+
+func TestLoadConfig_PollFromEnvVar(t *testing.T) {
+	t.Setenv("SBOM_UPLOADER_POLL", "true")
+
+	cfg, err := loadConfig(newFlagSet())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Poll {
+		t.Error("Poll: expected true from SBOM_UPLOADER_POLL env var, got false")
+	}
+}
+
+func TestLoadConfig_LatestFromEnvVar(t *testing.T) {
+	t.Setenv("SBOM_UPLOADER_LATEST", "false")
+
+	cfg, err := loadConfig(newFlagSet())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Latest {
+		t.Error("Latest: expected false from SBOM_UPLOADER_LATEST env var, got true")
+	}
+}
+
+func TestLoadConfig_FromFlags(t *testing.T) {
+	flags := newFlagSet()
+	err := flags.Parse([]string{
+		"--url", "https://from-flag.com",
+		"--api-key", "flag-key",
+		"--name", "flag-project",
+		"--version", "2.0.0",
+		"--parent", "flag-parent",
+		"--tags", "a,b",
+		"--sbom", "/flag/sbom.json",
+		"--poll",
+		"--latest=false",
+	})
+	if err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	cfg, err := loadConfig(flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.URL != "https://from-flag.com" {
+		t.Errorf("URL: got %q, want %q", cfg.URL, "https://from-flag.com")
+	}
+	if cfg.APIKey != "flag-key" {
+		t.Errorf("APIKey: got %q, want %q", cfg.APIKey, "flag-key")
+	}
+	if cfg.Name != "flag-project" {
+		t.Errorf("Name: got %q, want %q", cfg.Name, "flag-project")
+	}
+	if cfg.Version != "2.0.0" {
+		t.Errorf("Version: got %q, want %q", cfg.Version, "2.0.0")
+	}
+	if cfg.Parent != "flag-parent" {
+		t.Errorf("Parent: got %q, want %q", cfg.Parent, "flag-parent")
+	}
+	if cfg.Tags != "a,b" {
+		t.Errorf("Tags: got %q, want %q", cfg.Tags, "a,b")
+	}
+	if cfg.SBOM != "/flag/sbom.json" {
+		t.Errorf("SBOM: got %q, want %q", cfg.SBOM, "/flag/sbom.json")
+	}
+	if !cfg.Poll {
+		t.Error("Poll: expected true from --poll flag, got false")
+	}
+	if cfg.Latest {
+		t.Error("Latest: expected false from --latest=false flag, got true")
+	}
+}
+
+func TestLoadConfig_FlagOverridesEnvVar(t *testing.T) {
+	t.Setenv("SBOM_UPLOADER_URL", "https://from-env.com")
+
+	flags := newFlagSet()
+	if err := flags.Parse([]string{"--url", "https://from-flag.com"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	cfg, err := loadConfig(flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.URL != "https://from-flag.com" {
+		t.Errorf("URL: expected flag to override env var, got %q", cfg.URL)
+	}
+}
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	cfg, err := loadConfig(newFlagSet())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Poll {
+		t.Error("Poll: expected false by default, got true")
+	}
+	if !cfg.Latest {
+		t.Error("Latest: expected true by default, got false")
+	}
+}
+
+// --- Config.validate ---
+
+func validConfig() *Config {
+	return &Config{
+		URL:     "https://example.com",
+		APIKey:  "key",
+		Name:    "project",
+		Parent:  "parent",
+		Version: "1.0.0",
+	}
+}
+
+func TestValidate_PassesWithAllRequiredFields(t *testing.T) {
+	if err := validConfig().validate(); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_RequiredFields(t *testing.T) {
+	tests := []struct {
+		field   string
+		mutate  func(*Config)
+		wantMsg string
+	}{
+		{"URL", func(c *Config) { c.URL = "" }, "url"},
+		{"APIKey", func(c *Config) { c.APIKey = "" }, "api-key"},
+		{"Name", func(c *Config) { c.Name = "" }, "name"},
+		{"Parent", func(c *Config) { c.Parent = "" }, "parent"},
+		{"Version", func(c *Config) { c.Version = "" }, "version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			cfg := validConfig()
+			tt.mutate(cfg)
+			err := cfg.validate()
+			if err == nil {
+				t.Fatalf("expected error for missing %s, got nil", tt.field)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,14 +13,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 
 	"github.com/hashicorp/go-retryablehttp"
-)
-
-var (
-	v *viper.Viper
 )
 
 type Tag struct {
@@ -60,20 +54,7 @@ func main() {
 		Short: "Uploads SBOM to Dependency-Track",
 		RunE:  runUploader,
 	}
-
-	// Initialise flags
 	setFlags(rootCmd.Flags())
-
-	// Create the viper instance
-	v = viper.New()
-	v.SetEnvPrefix("SBOM_UPLOADER")
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	v.AutomaticEnv()
-	err := v.BindPFlags(rootCmd.Flags())
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to bind flags: %v\n", err)
-		os.Exit(1)
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Execution failed: %v\n", err)
@@ -166,7 +147,7 @@ func ensureParentExists(dependencyTrackUrl string, dependencyTrackKey string, pa
 	return nil
 }
 
-func uploadSbom(dependencyTrackUrl string, dependencyTrackKey string, projectName string, parentName string, projectVersion string, sbomFilePath string, tags string, client *retryablehttp.Client) (string, error) {
+func uploadSbom(dependencyTrackUrl string, dependencyTrackKey string, projectName string, parentName string, projectVersion string, sbomFilePath string, tags string, latest bool, client *retryablehttp.Client) (string, error) {
 	// Read SBOM from file or stdin
 	var sbomContent []byte
 	var err error
@@ -209,7 +190,7 @@ func uploadSbom(dependencyTrackUrl string, dependencyTrackKey string, projectNam
 	_ = writer.WriteField("autoCreate", "true")
 	_ = writer.WriteField("tags", tags)
 
-	if v.GetBool("latest") {
+	if latest {
 		_ = writer.WriteField("isLatest", "true")
 	}
 
@@ -320,53 +301,33 @@ func fetchProjectSummary(dependencyTrackUrl string, dependencyTrackKey string, p
 	return &project, nil
 }
 
-func runUploader(cmd *cobra.Command, args []string) error {
+func runUploader(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadConfig(cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
 
-	dependencyTrackUrl := v.GetString("url")
-	dependencyTrackKey := v.GetString("api-key")
-	projectName := v.GetString("name")
-	parentName := v.GetString("parent")
-	projectVersion := v.GetString("version")
-	sbomFilePath := v.GetString("sbom")
-	// Check required inputs
-	if dependencyTrackUrl == "" {
-		return fmt.Errorf("missing required inputs: url (via flags or env)")
-	}
-	if dependencyTrackKey == "" {
-		return fmt.Errorf("missing required inputs: api-key (via flags or env)")
-	}
-	if projectName == "" {
-		return fmt.Errorf("missing required inputs: name (via flags or env)")
-	}
-	if parentName == "" {
-		return fmt.Errorf("missing required inputs: name (via flags or env)")
-	}
-	if projectVersion == "" {
-		return fmt.Errorf("missing required inputs: version (via flags or env)")
-	}
-	tags := ""
-	if projectTags := v.GetString("tags"); projectTags != "" {
-		tags = projectTags
+	if err := cfg.validate(); err != nil {
+		return err
 	}
 
 	client := newDefaultRetryClient()
 
-	err := ensureParentExists(dependencyTrackUrl, dependencyTrackKey, parentName, tags, client)
-	if err != nil {
+	if err := ensureParentExists(cfg.URL, cfg.APIKey, cfg.Parent, cfg.Tags, client); err != nil {
 		return err
 	}
-	token, err := uploadSbom(dependencyTrackUrl, dependencyTrackKey, projectName, parentName, projectVersion, sbomFilePath, tags, client)
+	token, err := uploadSbom(cfg.URL, cfg.APIKey, cfg.Name, cfg.Parent, cfg.Version, cfg.SBOM, cfg.Tags, cfg.Latest, client)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("✅ SBOM upload successful.")
-	if v.GetBool("poll") {
+	if cfg.Poll {
 		fmt.Println("⏳ Polling until fully imported...")
-		if err := pollImport(dependencyTrackUrl, dependencyTrackKey, token, client, 2*time.Second); err != nil {
+		if err := pollImport(cfg.URL, cfg.APIKey, token, client, 2*time.Second); err != nil {
 			return err
 		}
-		project, err := fetchProjectSummary(dependencyTrackUrl, dependencyTrackKey, projectName, projectVersion, client)
+		project, err := fetchProjectSummary(cfg.URL, cfg.APIKey, cfg.Name, cfg.Version, client)
 		if err != nil {
 			return err
 		}
@@ -379,18 +340,6 @@ func runUploader(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func setFlags(s *pflag.FlagSet) {
-	s.String("url", "", "Dependency-Track API base URL or env SBOM_UPLOADER_URL")
-	s.String("api-key", "", "Dependency-Track API key or env SBOM_UPLOADER_API_KEY")
-	s.String("name", "", "Project name or env SBOM_UPLOADER_NAME")
-	s.String("version", "", "Project version or env SBOM_UPLOADER_VERSION")
-	s.String("parent", "", "Parent project name or env SBOM_UPLOADER_PARENT")
-	s.Bool("latest", true, "Mark as latest version (default true)")
-	s.Bool("poll", false, "Poll until import completes or env SBOM_UPLOADER_POLL")
-	s.String("tags", "", "Comma-separated project tags or env SBOM_UPLOADER_TAGS")
-	s.String("sbom", "", "Path to SBOM file (optional; otherwise read from stdin)")
 }
 
 func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -13,13 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/spf13/viper"
 )
-
-// setupViper initialises the global viper instance that uploadSbom() reads from.
-func setupViper() {
-	v = viper.New()
-}
 
 // noRetryClient returns a client with retries disabled, suitable for unit tests.
 func noRetryClient() *retryablehttp.Client {
@@ -29,7 +23,6 @@ func noRetryClient() *retryablehttp.Client {
 }
 
 // writeTempSbom writes content to a temp file and returns its path.
-
 func writeTempSbom(t *testing.T, content []byte) string {
 	t.Helper()
 	tmp, err := os.CreateTemp(t.TempDir(), "sbom-*.json")
@@ -70,10 +63,9 @@ func TestUploadSbom_Returns200(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setupViper()
 	sbomPath := writeTempSbom(t, []byte(`{"bomFormat":"CycloneDX"}`))
 
-	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", noRetryClient())
+	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", false, noRetryClient())
 	if err != nil {
 		t.Errorf("expected nil error, got: %v", err)
 	}
@@ -86,10 +78,9 @@ func TestUploadSbom_400ReturnsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setupViper()
 	sbomPath := writeTempSbom(t, []byte(`THIS IS NOT JSON`))
 
-	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", noRetryClient())
+	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", false, noRetryClient())
 	if err == nil {
 		t.Error("expected error for HTTP 400, got nil")
 	}
@@ -101,10 +92,9 @@ func TestUploadSbom_500ReturnsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setupViper()
 	sbomPath := writeTempSbom(t, []byte(`{}`))
 
-	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", noRetryClient())
+	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", false, noRetryClient())
 	if err == nil {
 		t.Error("expected error for HTTP 500, got nil")
 	}
@@ -126,10 +116,9 @@ func TestUploadSbom_SendsFormFields(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setupViper()
 	sbomPath := writeTempSbom(t, []byte(`{"bomFormat":"CycloneDX"}`))
 
-	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "2.0.0", sbomPath, "tag1,tag2", noRetryClient())
+	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "2.0.0", sbomPath, "tag1,tag2", false, noRetryClient())
 	if err != nil {
 		t.Fatalf("uploadSbom returned unexpected error: %v", err)
 	}
@@ -163,11 +152,9 @@ func TestUploadSbom_IsLatestFieldSentWhenTrue(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setupViper()
-	v.Set("latest", true)
 	sbomPath := writeTempSbom(t, []byte(`{"bomFormat":"CycloneDX"}`))
 
-	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", noRetryClient())
+	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", true, noRetryClient())
 	if err != nil {
 		t.Fatalf("uploadSbom returned unexpected error: %v", err)
 	}
@@ -188,11 +175,9 @@ func TestUploadSbom_IsLatestFieldAbsentWhenFalse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	setupViper()
-	// v.GetBool("latest") defaults to false
 	sbomPath := writeTempSbom(t, []byte(`{"bomFormat":"CycloneDX"}`))
 
-	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", noRetryClient())
+	_, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", false, noRetryClient())
 	if err != nil {
 		t.Fatalf("uploadSbom returned unexpected error: %v", err)
 	}
@@ -202,10 +187,27 @@ func TestUploadSbom_IsLatestFieldAbsentWhenFalse(t *testing.T) {
 }
 
 func TestUploadSbom_MissingFileReturnsError(t *testing.T) {
-	setupViper()
-	_, err := uploadSbom("http://localhost", "key", "proj", "parent", "1.0", "/nonexistent/path.json", "", noRetryClient())
+	_, err := uploadSbom("http://localhost", "key", "proj", "parent", "1.0", "/nonexistent/path.json", "", false, noRetryClient())
 	if err == nil {
 		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestUploadSbom_ReturnsToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "my-token-xyz"})
+	}))
+	defer server.Close()
+
+	sbomPath := writeTempSbom(t, []byte(`{"bomFormat":"CycloneDX"}`))
+
+	token, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", false, noRetryClient())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "my-token-xyz" {
+		t.Errorf("token: got %q, want %q", token, "my-token-xyz")
 	}
 }
 
@@ -385,25 +387,6 @@ func TestPollImport_TimesOut(t *testing.T) {
 	err := pollImport(server.URL, "test-key", "test-token", noRetryClient(), 0)
 	if err == nil {
 		t.Error("expected error when server is unreachable, got nil")
-	}
-}
-
-func TestUploadSbom_ReturnsToken(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"token": "my-token-xyz"})
-	}))
-	defer server.Close()
-
-	setupViper()
-	sbomPath := writeTempSbom(t, []byte(`{"bomFormat":"CycloneDX"}`))
-
-	token, err := uploadSbom(server.URL, "test-key", "my-project", "my-parent", "1.0.0", sbomPath, "", noRetryClient())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if token != "my-token-xyz" {
-		t.Errorf("token: got %q, want %q", token, "my-token-xyz")
 	}
 }
 


### PR DESCRIPTION
Turns out that the boolean parsing wasn't working as expected, due to a bonkers "known issue" - https://github.com/spf13/viper/issues/671.

This extracts out the config loading, and validation, and adds tests for it.